### PR TITLE
Implements infoCards

### DIFF
--- a/_includes/bakery-wiki/components/infoCard.html
+++ b/_includes/bakery-wiki/components/infoCard.html
@@ -1,0 +1,27 @@
+{%- assign title = page.title-%}
+{%- assign lr = page.lr | default: "right" -%}
+{%- assign imageURL = page.image | default:
+"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTfpbNRYOrK9HJpurmGakWEIv_zeu25-fvBug&s" -%}
+<table class="info" lr="{{lr}}">
+    <tr>
+        <th colspan="100%">{{title}}</th>
+    </tr>
+    <tr>
+        <td colspan="100%"><img src="{{imageURL}}" alt=""></td>
+    </tr>
+    {%- for row in page.infoCard -%}
+    <tr>
+        {%- assign colspan = 100 | divided_by: row.size -%}
+        {%- if row.first[0] -%}
+            {%- for item in row -%}
+                <td colspan="50%">{{item[0]}}</td>
+                <td colspan="50%">{{item[1]}}</td>
+            {%- endfor -%}
+        {%- else -%}
+            {%- for column in row -%}
+                <td colspan="{{colspan}}%">{{column}}</td>
+            {%- endfor -%}
+        {%- endif -%}
+    </tr>
+    {%- endfor -%}
+</table>

--- a/_includes/bakery-wiki/components/infoCard.html
+++ b/_includes/bakery-wiki/components/infoCard.html
@@ -1,27 +1,60 @@
-{%- assign title = page.title-%}
-{%- assign lr = page.lr | default: "right" -%}
-{%- assign imageURL = page.image | default:
-"https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTfpbNRYOrK9HJpurmGakWEIv_zeu25-fvBug&s" -%}
+{%- assign title = page.info.name | default: include.title -%}
+{%- assign nicknames = page.info.nicknames | default: include.nicknames -%}
+{%- assign pronouns = page.info.pronouns | default: include.pronouns -%}
+{%- assign imageURL = page.info.image | default: include.imageURL -%}
+{%- assign lr = page.lr | default: include.lr | default: "right" -%}
+{% comment %} Turns `nil` truthy, making the default behavior to show the infocard.{% endcomment %}
+{% if page.staticInfoEnabled == nil %}
+  {%- assign staticInfoEnabled = true -%}
+{% else %}
+  {%- assign staticInfoEnabled = page.staticInfoEnabled -%}
+{%endif%}
 <table class="info" lr="{{lr}}">
-    <tr>
-        <th colspan="100%">{{title}}</th>
-    </tr>
-    <tr>
+  {% if staticInfoEnabled %}
+    {% if title %}
+      <tr>
+          <th colspan="100%">{{title}}</th>
+      </tr>
+    {% endif %}
+    {% if imageURL %}
+      <tr>
         <td colspan="100%"><img src="{{imageURL}}" alt=""></td>
-    </tr>
-    {%- for row in page.infoCard -%}
-    <tr>
-        {%- assign colspan = 100 | divided_by: row.size -%}
-        {%- if row.first[0] -%}
-            {%- for item in row -%}
-                <td colspan="50%">{{item[0]}}</td>
-                <td colspan="50%">{{item[1]}}</td>
-            {%- endfor -%}
-        {%- else -%}
-            {%- for column in row -%}
-                <td colspan="{{colspan}}%">{{column}}</td>
-            {%- endfor -%}
-        {%- endif -%}
-    </tr>
-    {%- endfor -%}
+      </tr>
+    {% endif %}
+    {% if nicknames %}
+      <tr>
+        <td colspan="50%">Nicknames:</td>
+        <td>
+          {% for nick in nicknames %}
+            {{nick}}<br>
+          {% endfor %}
+        </td>
+      </tr>
+    {% endif %}
+    {% if pronouns %}
+      <tr>
+        <td colspan="50%">Pronouns:</td>
+        <td>
+          {% for pron in pronouns %}
+            {{pron}}<br>
+          {% endfor %}
+        </td>
+      </tr>
+    {% endif %}
+  {% endif %}
+  {%- for row in page.infoCard -%}
+  <tr>
+      {%- assign colspan = 100 | divided_by: row.size -%}
+      {%- if row.first[0] -%}
+          {%- for item in row -%}
+              <td colspan="50%">{{item[0]}}</td>
+              <td colspan="50%">{{item[1]}}</td>
+          {%- endfor -%}
+      {%- else -%}
+          {%- for column in row -%}
+              <td colspan="{{colspan}}%">{{column}}</td>
+          {%- endfor -%}
+      {%- endif -%}
+  </tr>
+  {%- endfor -%}
 </table>

--- a/_includes/bakery-wiki/components/infoCard.html
+++ b/_includes/bakery-wiki/components/infoCard.html
@@ -24,7 +24,7 @@
     {% if nicknames %}
       <tr>
         <td colspan="50%">Nicknames:</td>
-        <td>
+        <td colspan="50%">
           {% for nick in nicknames %}
             {{nick}}<br>
           {% endfor %}
@@ -34,7 +34,7 @@
     {% if pronouns %}
       <tr>
         <td colspan="50%">Pronouns:</td>
-        <td>
+        <td colspan="50%">
           {% for pron in pronouns %}
             {{pron}}<br>
           {% endfor %}
@@ -47,7 +47,7 @@
       {%- assign colspan = 100 | divided_by: row.size -%}
       {%- if row.first[0] -%}
           {%- for item in row -%}
-              <td colspan="50%">{{item[0]}}</td>
+              <td colspan="50%">{{item[0]}}:</td>
               <td colspan="50%">{{item[1]}}</td>
           {%- endfor -%}
       {%- else -%}

--- a/_layouts/bakery-theme-person.html
+++ b/_layouts/bakery-theme-person.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  {%- include bakery-wiki/head.html -%}
+        {%- comment -%} This injects the frontmatter accent colors into the body css, overwriting the initial variables imported alongside the header at line 3
+        This does NOT need default values, the default should fallback to the stylesheets.
+        The if statements avoid asigning empty variables, which chromium browsers do not like, at all, chromium sucks. {%- endcomment -%}
+        {%- comment -%}============================================================================================== {%- endcomment -%}
+  {%- if page.accent-light -%}
+  <style>
+    body {
+      --accent-light: {{ page.accent-light }};
+    }
+  </style>
+  {%- endif -%}
+  {%- if page.accent-dark -%}
+  <style>
+    body {
+      --accent-dark: {{ page.accent-dark }};
+    }
+  </style>
+  {%- endif -%}
+  {%- comment -%}============================================================================================== {% endcomment -%}
+  <body data-theme>
+    {%- include bakery-wiki/navBar.html -%}
+    {%- comment -%} Add the sidebar unless the page has it disabled {%- endcomment -%}
+    {%- if page.sidebar != false -%}
+    <menu>
+        {%- include bakery-wiki/toc/toc-lib.html title=" " minHeaders=1 html=content sanitize=true class="SideBar" id="git-wiki-toc" h_min=1 h_max=3 -%}
+    </menu>
+    {%- endif -%}
+    <main>
+        {%- if page.title -%}
+        <h1 id="art-title" >{{page.title}}</h1>
+        {%- endif -%}
+        {%- include bakery-wiki/components/infoCard.html -%}
+        {{ content }}
+        {%- assign items = site.html_pages -%}
+        {%- for page in items -%}
+        {%- assign url = page.url | relative_url -%}
+        {%- assign urls = urls | append: url | append: "," -%}
+        {%- endfor -%}
+    </main>
+  <script type="text/javascript">
+    $(document).ready(function () {
+        $(document.body).checkLinks("{{ urls }}".split(","));
+        console.log("Henwo");
+    });
+  </script>
+  </body>
+
+</html>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,17 @@
-{% include bakery-wiki/components/charCard.html title="UwU" imageURL="https://yt3.ggpht.com/IXnjZR-4D2JX8HjIwZloE088y2taeis8YFpR-NFaP2N_6P7z4JI3cc6SEg-N-iOGAeyP3zanFw=s600-c-k-c0x00ffffff-no-rj-rp-mo" table='uwu|What|Youtube|Streams,None|Socials,None|uwu,owo,uvu|check,this,out!,neat.|<img src="https://s3-eu-west-2.amazonaws.com/photos.thearticle.com/app/production/articles/2839/cover_desktop_the-rise-and-fall-of-the-fax-machine.jpg" title="Spooky." alt="Even image alts work!">' %}
-# Text blocks
+---
+accent-dark: "#990000"
+accent-light: "#990000"
+layout: bakery-theme-person
+image: https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg
+embed: card
+infoCard:
+    - Occupation: "3D designer"
+    - ["stuff<hr>uwu","a<hr>a"]
+    - Hobbies: "Managing twitch<hr>Complaining"
+    - ["<img src='https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg'>"]
+    - Occupation: "a"
+---  
+
 ## Links
 
 [This is a link]()

--- a/index.md
+++ b/index.md
@@ -1,16 +1,22 @@
 ---
 accent-dark: "#990000"
 accent-light: "#990000"
+embedImage: https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg
+embedType: card
 layout: bakery-theme-person
-image: https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg
-embed: card
+# staticInfoEnabled: false
+info:
+  name: "The Twat"
+  nicknames: ["Raz","Cat","Catman"]
+  pronouns: ["He/Him"]
+  image: "https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg"
 infoCard:
-    - Occupation: "3D designer"
-    - ["stuff<hr>uwu","a<hr>a"]
-    - Hobbies: "Managing twitch<hr>Complaining"
-    - ["<img src='https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg'>"]
-    - Occupation: "a"
----  
+  - Occupation: "3D designer"
+  - ["stuff<hr>uwu","a<hr>a", "meow"]
+  - Hobbies: "Managing twitch<hr>Complaining"
+  - ["<img src='https://razvii22.github.io/bakery-wiki/assets/images/pfps/smugFuck.jpg'>"]
+  - Occupation: "a"
+---
 
 ## Links
 


### PR DESCRIPTION
Info cards are identical to charCards, but function through the frontmatter header instead of the include tag.
Implements a bakery-theme-person.html layout template that integrates the info card directly, skipping the `{% include %}` entirely.
This deprecates charCards, however doesn't remove the component to avoid breaking existing pages before they can be updated.
Allows external pages, such as index pages, to reliably access data that would otherwise only be accessible to that page's charCards.